### PR TITLE
Throw exception when trying to update the time on a realtime clock

### DIFF
--- a/src/carma_clock.cpp
+++ b/src/carma_clock.cpp
@@ -52,6 +52,10 @@ timeStampSeconds CarmaClock::nowInSeconds() const {
 }
 
 void CarmaClock::update(timeStampMilliseconds current_time) {
+    // check for sim time and throw exception if not in sim
+    if (!_is_simulation_mode) {
+        throw std::invalid_argument("Clock is not in simulation mode!");
+    }
     _current_time = current_time;
     if (!_is_initialized) {
         // if not initialized then do it and let anyone waiting know

--- a/test/test_carma_clock.cpp
+++ b/test/test_carma_clock.cpp
@@ -39,6 +39,20 @@ TEST(test_carma_clock, test_system_time_sleep_until)
     EXPECT_NEAR(SYSTEM_SLEEP_TIME, msCount, 5);
 }
 
+TEST(test_carma_clock, test_system_time_update_exception)
+{
+    // try a real clock
+    CarmaClock clock;
+    bool execptionThrown = false;
+    try {
+        clock.update(0);
+    } catch (std::exception & e) {
+        // should not be able to update system clock
+        execptionThrown = true;
+    }
+    EXPECT_TRUE(execptionThrown);
+}
+
 TEST(test_carma_clock, test_sim_time_initialization)
 {
     // try a sim clock


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Throw an exception when the update function is called for a non-simulated clock.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
