### PR TITLE
Remove debian package python and pybind11 dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - architecture: x64
             ubuntu: bionic
-            build: true
+            build: false
           - architecture: x64
             ubuntu: focal
             build: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,11 @@ on:
      - 'master'
      - 'develop'
      - 'release/*'
-  pull_request:
-      types: [opened, synchronize, reopened]
+# make GHA actions use node16 which still works with bionic
+# See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+# Unclear how long this will work though. Remove bionic from matrix as soon as we no longer need to support it.
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   build-package:
     strategy:
@@ -16,7 +19,7 @@ jobs:
         include:
           - architecture: x64
             ubuntu: bionic
-            build: false
+            build: true
           - architecture: x64
             ubuntu: focal
             build: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           - architecture: arm64
             ubuntu: jammy
             build: true
-    uses: usdot-fhwa-stol/actions/.github/workflows/cpp-module-build.yml@main
+    uses: usdot-fhwa-stol/actions/.github/workflows/cpp-module-build.yml@fix-node-deprecation-warnings
     with:
       bucket-codename: ${{ matrix.ubuntu }}
       build: ${{ matrix.build }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           - architecture: arm64
             ubuntu: jammy
             build: true
-    uses: usdot-fhwa-stol/actions/.github/workflows/cpp-module-build.yml@fix-node-deprecation-warnings
+    uses: usdot-fhwa-stol/actions/.github/workflows/cpp-module-build.yml@main
     with:
       bucket-codename: ${{ matrix.ubuntu }}
       build: ${{ matrix.build }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build Workflow
 
 on:
+  workflow_dispatch:
   push:
    branches:
      - 'master'

--- a/.github/workflows/sonar-scanner.yml
+++ b/.github/workflows/sonar-scanner.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   # Trigger analysis when pushing in master or pull requests, and when creating
   # a pull request.
   push:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH "$ENV{CARMA_OPT_DIR}/cmake")
 set(CMAKE_CXX_STANDARD 17)
 
 
-project(carma_clock
+project(carma-clock
     DESCRIPTION "CARMA time library"
     HOMEPAGE_URL https://github.com/usdot-fhwa-stol/carma-time-lib
 	VERSION 0.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(carma-clock
 
 option(BUILD_PYTHON_BINDINGS 
     "BUILD PYTHON BINDINGS is used to configure whether or not to including building python module bindings into the cmake build process.
-     **NOTE** Build python bindings is currently only support for native builds (not supported for cross-compile builds) " ON)
+     **NOTE** Build python bindings is currently only support for native builds (not supported for cross-compile builds) " OFF)
 
 include(cmake/dependencies.cmake)
 add_library(${PROJECT_NAME} SHARED )

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ To import this library as a python module the following is necessary.
 # This path can be added via the sys module or by directly appending the PYTHON_PATH environment variable.
 import sys
 sys.path.append('/path/to/library')
-# Import module
-import libcarma_clock
+# Import C++ library as python module
+import importlib
+libcarma_clock = importlib.import_module("libcarma-clock")
+
 ...
 # Initialize CARMA Clock object
 clock = libcarma_clock.CarmaClock(False)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ target_link_libraries( ${PROJECT_NAME} PUBLIC
 ### Importing as Python Module
 > [!IMPORTANT]\
 >Python module support is currently only available for x86/amd devices
-To import this library as a python module the following is necessary. A
+To import this library as a python module the following is necessary.
 
 ```python
 # This path can be added via the sys module or by directly appending the PYTHON_PATH environment variable.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ apt install carma-clock-1
 ```
 
 This steps above add the relavent STOL apt repository for pulling correct debian package.
+> [!IMPORTANT]\
+>The python bindings for **CARMA Time Lib** are not included by default in the debian package. To install this library for use
+with python we suggest you install it locally with the following steps
+
+```shell
+./install_dependencies.sh
+cmake -Bbuild -DBUILD_PYTHON_BINDINGS=ON .
+cmake --build build
+```
 
 ### Including with CMake (C++)
 To find and link this library via CMake the following commands are necessary
@@ -58,12 +67,12 @@ target_link_libraries( ${PROJECT_NAME} PUBLIC
 ### Importing as Python Module
 > [!IMPORTANT]\
 >Python module support is currently only available for x86/amd devices
-To import this library as a python module the following is necessary
+To import this library as a python module the following is necessary. A
 
 ```python
 # This path can be added via the sys module or by directly appending the PYTHON_PATH environment variable.
 import sys
-sys.path.append('/opt/carma/lib/')
+sys.path.append('/path/to/library')
 # Import module
 import libcarma_clock
 ...

--- a/carma_clock_py/python_wrapper_test.py
+++ b/carma_clock_py/python_wrapper_test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 import unittest
-import libcarma_clock
+import importlib
+libcarma_clock = importlib.import_module("libcarma-clock")
+# import libcarma_clock
 import time
 
 """Test Case for testing basic CarmaClock functionality in python


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The PR addresses several issues. The most important of which is removing Python and PyBind as a dependency from the debian package we push to our debian package repository. These dependencies were added to facilitate usage of our library by the MMITTS system which has yet to take place. They have the unintended impact that all tools currently consuming this apt package now also need python3 module and pybind11 installed and discoverable by CMake. While the build process to compile this our library into a python consumable module still works, this PR changes our build instructions to by default not include the python bindings. In the future we should consider pushing two separate debian packages (one with python bindings and one without) or determine whether we can wrap and push this as a python module.

The second fix was related to CMake config installation being broken by a recent change of the CMake project from `carma-clock` to `carma_clock`. This change was made initially to allow for our package to be python consumable since python does not allow `-` characters in module names. Changing the package name also had the unexpected result that it broke our CMake config files.  After some investigation I discovered the `importlib.import_module("")` functionality that allowed for importing python modules under different names which resolved the initial issue and allowed use to revert to the original cmake project name.

The last change is to the CI process. Some recent efforts by GitHub to update NodeJS version used by all their runners has the unintended impact that it has some incompatibility with bionic. There is currently as flag that can be set to avoid this issue by allowing the runners to use deprecated versions of nodeJS. Ultimately we will discontinue support for bionic as soon as we remove it from CARMA Streets. I also added manual triggers for workflows and prevented our workflows from pushing debian packages during pull requests.
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context
During XIL Cloud Verification testing, when attempting to rebuild CARMA Streets services with a `carma-clock` dependency it was discovered that updates to this library to provide python bindings had broken build processes for including it in C++ applications already using it.

The first problem was project naming. After renaming the cmake project from `carma-clock` to `carma_clock` to avoid invalid `-` characters for python modules, CMake files that were trying to include this library as `carma-clock` could not find it. We found a solution using the python `importlib` to rename the C++ library as a python module and remove invalid characters like `-` from the resulting name.

The second problem was that the new `carma-clock` library had a dependency and CMake being able to find `Python3 Modules` and `pybind11`. CARMA Streets C++ services did not have these dependencies installed and discoverable for CMake so we have removed these dependencies. Currently we have update documentation to only allow for local building of python bindings and we plan in the future to host separate apt packages for the C++ package and the C++ package with python bindings.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
CDASim testing 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
