### PR TITLE
Fix allow cmake build without tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ project(carma-clock
 option(BUILD_PYTHON_BINDINGS 
     "BUILD PYTHON BINDINGS is used to configure whether or not to including building python module bindings into the cmake build process.
      **NOTE** Build python bindings is currently only support for native builds (not supported for cross-compile builds) " OFF)
+option(BUILD_TESTS "Build tests" OFF)
+option(CREATE_DEB_PACKAGE "Create Debian Package" OFF)
 
 include(cmake/dependencies.cmake)
 add_library(${PROJECT_NAME} SHARED )
@@ -30,8 +32,10 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 
 include(CommonSource)
-include(Testing)
-include(CodeCoverage)
+if (BUILD_TESTS)
+    include(Testing)
+    include(CodeCoverage)
+endif()
 include(InstallingGeneral)
 include(InstallingConfigs)
 
@@ -60,14 +64,19 @@ if (${BUILD_PYTHON_BINDINGS})
     )
     # set up test for python module binding 
     FILE(COPY carma_clock_py/python_wrapper_test.py DESTINATION .)
-    add_test(NAME test_carma_clock_python_module_binding COMMAND ${PYTHON_EXECUTABLE} python_wrapper_test.py )
+    if (BUILD_TESTS)
+
+        add_test(NAME test_carma_clock_python_module_binding COMMAND ${PYTHON_EXECUTABLE} python_wrapper_test.py )
+    endif()
+
     # set cpack depedencies
     set(CPACK_DEBIAN_PACKAGE_DEPENDS python3-dev)
     # remove debug post fix for library. Required due to import naming for python module import
     set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "")
 endif()
-
-include(Packing)
+if (CREATE_DEB_PACKAGE)
+    include(Packing)
+endif()
 
 
 

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-${CARMA_OPT_DIR}/scripts/build_script.sh -p $@
+${CARMA_OPT_DIR}/scripts/build_script.sh -p $@ -DBUILD_TESTS=ON -DCREATE_DEB_PACKAGE=ON


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Create cmake options to skip building and executing unit tests.
> [!CAUTION]
> This Pull Request depends on the changes in the https://github.com/usdot-fhwa-stol/carma-builds/pull/38 Pull request. Merging without these changes will not result in the desired functionality
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context
Project should be compilable without having to compile unit tests
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
